### PR TITLE
Improve marshalling of Ruby hashes to JS

### DIFF
--- a/lib/rhino/wormhole.rb
+++ b/lib/rhino/wormhole.rb
@@ -20,6 +20,7 @@ module Rhino
       when String,Numeric       then object
       when TrueClass,FalseClass then object
       when Array                then J::NativeArray.new(object.to_java)
+      when Hash                 then ruby_hash_to_native(object)
       when Proc,Method          then RubyFunction.new(object)
       when NativeObject         then object.j      
       when J::Scriptable        then object
@@ -30,7 +31,17 @@ module Rhino
     def array(native)
       native.length.times.map {|i| ruby(native.get(i,native))}
     end
+
+    def ruby_hash_to_native(ruby_object)
+      native_object = NativeObject.new
+
+      ruby_object.each_pair do |k, v|
+        native_object[k] = v
+      end
+
+      native_object.j
+		end
     
-    module_function :ruby, :javascript, :array
+    module_function :ruby, :javascript, :array, :ruby_hash_to_native
   end
 end

--- a/spec/rhino/wormhole_spec.rb
+++ b/spec/rhino/wormhole_spec.rb
@@ -97,6 +97,13 @@ describe Rhino::To do
         a.get(3,a).should be(4)
       end
     end
+
+    it "converts ruby hashes into native objects" do
+      To.javascript({ :bare => true }).tap do |h|
+        h.should be_kind_of(J::NativeObject)
+        h.get("bare", h).should be(true)
+      end
+    end
     
     it "converts procs and methods into native functions" do
       to(lambda {|lhs,rhs| lhs * rhs}).tap do |f|


### PR DESCRIPTION
The coffee-script gem tries to call the CoffeeScript.compile function with two arguments, a string (of CoffeeScript code), and a hash (of options). It's impossible to compile CoffeeScript code using therubyrhino runtime with ExecJS at the moment, because the hash of options is passed over to javascript as a RubyObject, causing the compiler to blow up:

```
jruby-1.6.2 :003 > CoffeeScript.compile("")
NativeException: org.mozilla.javascript.JavaScriptException: TypeError: Cannot read property "expressions" from undefined (<eval>#8)
```

The change in this pull request makes sure the hash of options is passed over as a native JS object, so that it can be understood by the CoffeeScript compiler. I hope it doesn't break anything else!
