### PR TITLE
Avoid using a glob in jar_path

### DIFF
--- a/jar/rhino/jar_path.rb
+++ b/jar/rhino/jar_path.rb
@@ -1,7 +1,8 @@
 
 module Rhino
-  specs = Gem.loaded_specs["therubyrhino_jar"]
-  version = specs.version.to_s.split(".")
-  jar_file = "rhino-#{version[0]}.#{version[1]}R#{version[2]}.jar"
-  JAR_PATH = File.expand_path("../#{jar_file}", File.dirname(__FILE__))
+  JAR_VERSION = "1.7.4"
+  version_parts = JAR_VERSION.split(".")
+  current_dir = File.dirname(__FILE__)
+  jar_file = "rhino-#{version_parts[0]}.#{version_parts[1]}R#{version_parts[2]}.jar"
+  JAR_PATH = File.expand_path("../#{jar_file}", current_dir)
 end


### PR DESCRIPTION
In attempting to include therubyrhino in a compiled .jar file (using [warbler](https://github.com/jruby/warbler)), I ran into an issue with the `glob` call in `jar/rhino/jar_path.rb`.  It seems that `glob` does not behave as expected inside a .jar file, and apparently also exhibits inconsistent behavior between JRE 6 and JRE 7.  This pull request removes the glob and constructs the name of the jar by using the gem's version.
