### PR TITLE
Add license information to gemspecs

### DIFF
--- a/therubyrhino.gemspec
+++ b/therubyrhino.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
   s.homepage = %q{http://github.com/cowboyd/therubyrhino}
   s.rubyforge_project = %q{therubyrhino}
   s.extra_rdoc_files = ["README.md"]
+  s.license = "MIT"
 
   s.require_paths = ["lib"]
   s.files = `git ls-files`.split("\n").sort.

--- a/therubyrhino_jar.gemspec
+++ b/therubyrhino_jar.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
 
   s.summary     = "Rhino's jars packed for therubyrhino"
   s.description = %q{Rhino's js.jar classes packaged as a JRuby gem.}
+  s.license = "MPL-2.0"
 
   s.homepage = %q{http://github.com/cowboyd/therubyrhino}
   s.rubyforge_project = %q{therubyrhino}


### PR DESCRIPTION
I added the license information to the gemspecs.

I picked MIT for therubyrhino because of the [MIT license in the README](https://github.com/pivotal-sharknado/therubyrhino/blob/cac2b9512a5d82579b5cdb7f1c677a0ae6b0d590/README.md#license)

I picked MPL-2.0 for therubyrhino_jar because of the license information in [/jar/LICENSE.txt](https://github.com/pivotal-sharknado/therubyrhino/blob/cac2b9512a5d82579b5cdb7f1c677a0ae6b0d590/jar/LICENSE.txt)
