### PR TITLE
Travis: Choose Trusty to build, have language Ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,15 @@
+dist: trusty
+language: ruby
+env:
+  global:
+    - JRUBY_OPTS=--debug
 rvm:
   - jruby-18mode
-  - jruby-19mode
+  - jruby-1.7.26
+  - jruby-9.1.7.0
   - jruby-head
-#env:
-#  - JRUBY_OPTS="--1.8"
-#  - JRUBY_OPTS="--1.9"
+before_install:
+  - gem update --system
 branches:
   only:
     - master

--- a/Gemfile
+++ b/Gemfile
@@ -17,5 +17,5 @@ group :test do
   gem 'less', '>= 2.2.1', :require => nil
 end
 
-gem 'rake', :require => false, :group => :development
+gem 'rake', '< 11.0', :require => false, :group => :development
 gem 'jruby-openssl', :group => :development if JRUBY_VERSION < '1.7'


### PR DESCRIPTION
This WIP PR tries to update the builds so that they run on the supported platforms.

- Travis: Change to target an explicit version of JRuby 1.7 (the Ruby 1.9 series) - the previous expression made rvm target 9.0.5.0
- Rake must be an earlier version to use the RSpec version in use
- add `JRUBY_OPTS=--debug`

Issues we ran into:

- NullPointerExceptions on finding backtrace lines (comes from elsewhere)
- Backtrace line-finding on JRuby 9.1.8.0 turns into a Bundler "friendly error" which is presented to the user without much information (Bundler error presentation)

Observations:

- RSpec is quite old, perhaps a newer version is good for the project