### PR TITLE
Travis: jruby-9.1.13.0, jruby-1.7.27

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ env:
     - JRUBY_OPTS=--debug
 rvm:
   - jruby-18mode
-  - jruby-1.7.26
-  - jruby-9.1.7.0
+  - jruby-1.7.27
+  - jruby-9.1.13.0
   - jruby-head
 before_install:
-  - gem update --system
+  - gem install bundler
 branches:
   only:
     - master


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/09/06/jruby-9-1-13-0.html