### PR TITLE
gemspec: Drop defunct property rubyforge_project

### DIFF
--- a/therubyrhino.gemspec
+++ b/therubyrhino.gemspec
@@ -11,7 +11,6 @@ Gem::Specification.new do |s|
   s.summary = %q{Embed the Rhino JavaScript interpreter into JRuby}
   s.description = %q{Call javascript code and manipulate javascript objects from ruby. Call ruby code and manipulate ruby objects from javascript.}
   s.homepage = %q{http://github.com/cowboyd/therubyrhino}
-  s.rubyforge_project = %q{therubyrhino}
   s.extra_rdoc_files = ["README.md"]
   s.license = "MIT"
 

--- a/therubyrhino_jar.gemspec
+++ b/therubyrhino_jar.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
   s.license = "MPL-2.0"
 
   s.homepage = %q{http://github.com/cowboyd/therubyrhino}
-  s.rubyforge_project = %q{therubyrhino}
 
   s.require_paths = ["jar"]
   s.files = `git ls-files`.split("\n").sort.


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* [rubygems/rubygems#2436 deprecated the `rubyforge_project` property][2].

[1]: https://twitter.com/evanphx/status/399552820380053505
[2]: rubygems/rubygems#2436