### PR TITLE
README: Use rubyjs' Travis badge; drop old badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # therubyrhino
 
 [![Gem Version](https://badge.fury.io/rb/therubyrhino.svg)](http://badge.fury.io/rb/therubyrhino)
-[![Build Status](https://travis-ci.org/cowboyd/therubyrhino.svg?branch=master)](https://travis-ci.org/cowboyd/therubyrhino)
-[![Dependency Status](https://gemnasium.com/cowboyd/therubyrhino.svg)](https://gemnasium.com/cowboyd/therubyrhino)
+[![Build Status](https://travis-ci.org/rubyjs/therubyrhino.svg?branch=master)](https://travis-ci.org/rubyjs/therubyrhino)
 [![Join the chat at https://gitter.im/cowboyd/therubyracer](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/cowboyd/therubyracer?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Embed the Mozilla Rhino JavaScript interpreter into Ruby


### PR DESCRIPTION
  - The Gemnasium service closed, this commit drops the badge
  - The Travis build status badge pointed at the wrong project, which showed grey for "error"

The desired result:

- To link to the correct and failing (currently) Travis